### PR TITLE
Patch: Use regex t for student email rule

### DIFF
--- a/app/Rules/StudentEmail.php
+++ b/app/Rules/StudentEmail.php
@@ -15,24 +15,7 @@ class StudentEmail implements Rule
      */
     public function passes($attribute, $value)
     {
-        $username = explode('@', $value)[0];
-
-        return $this->isValidDomain($value) && $this->isValidUsername($username);
-    }
-
-    private function isValidDomain($value)
-    {
-        return str($value)->endsWith('@umindanao.edu.ph');
-    }
-
-    private function isValidUsername($username)
-    {
-        [$initialName, $lastName, $studentId, $postfix] = explode('.', $username);
-
-        return strlen($initialName) == 1
-            && strlen($lastName) > 0
-            && (strlen($studentId) == 6 && ctype_digit($studentId))
-            && $postfix == 'tc';
+        return preg_match('/^[a-z]\.[a-z]*\.(\d{6})(\.tc)?@umindanao\.edu\.ph$/', $value) === 1;
     }
 
     /**

--- a/tests/Feature/Rules/StudentEmailTest.php
+++ b/tests/Feature/Rules/StudentEmailTest.php
@@ -47,6 +47,11 @@ class StudentEmailTest extends TestCase
             'email',
             'f.lastname.123456.tc@gmail.com'
         ));
+
+        $this->assertFalse((new StudentEmail)->passes(
+            'email',
+            'f.lastname.123456.tc@umindanao.edu.phextracharacter'
+        ));
     }
 
     public function test_empty_postfix_in_username()
@@ -89,15 +94,15 @@ class StudentEmailTest extends TestCase
         ));
     }
 
-    public function test_incomplete_username()
+    public function test_valid_um_main_email()
     {
-        $this->assertFalse((new StudentEmail)->passes(
+        $this->assertTrue((new StudentEmail)->passes(
             'email',
             'f.lastname.123456@umindanao.edu.ph'
         ));
     }
 
-    public function test_valid_um_email()
+    public function test_valid_um_tagum_email()
     {
         $this->assertTrue((new StudentEmail)->passes(
             'email',


### PR DESCRIPTION
- Use regex when matching student email
- Allow um main email, and refine test cases
